### PR TITLE
Fix: residual effects from temperature profiles modal

### DIFF
--- a/js/component/modal/temperature_profiles_info.js
+++ b/js/component/modal/temperature_profiles_info.js
@@ -42,8 +42,7 @@ beestat.component.modal.temperature_profiles_info.prototype.decorate_contents_ =
           });
       }
 
-      profile.deltas = deltas_converted;
-      const linear_trendline = beestat.math.get_linear_trendline(profile.deltas);
+      const linear_trendline = beestat.math.get_linear_trendline(deltas_converted);
 
       fields.push({
         'name': beestat.series['indoor_' + type + '_delta'].name,


### PR DESCRIPTION
Opening the 'More Info' modal on the temperature profiles graph with a selected temperature unit of Celsius would cause the deltas in `beestat.cache.thermostat[].profile.temperature[]` to be converted then stored back.  This would cause residual effects outside it's scope.  Repeatedly opening the modal would then also repeat the conversion assuming the input values were in Fahrenheit when they had already been converted.